### PR TITLE
Add support for Visual Studio 2019 Professional

### DIFF
--- a/SoftwareCo/SoftwareCo/source.extension.vsixmanifest
+++ b/SoftwareCo/SoftwareCo/source.extension.vsixmanifest
@@ -10,6 +10,7 @@
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0]" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,17.0]" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Installation fails on Visual Studio 2019 Pro because the manifest does not match against it, giving the installing user a message 
that no compatible products are installed. This adds VS 2019 Pro to the manifest and permits install.